### PR TITLE
Updates the form class names to use rails pattern

### DIFF
--- a/lib/attachy/models/attachy/viewer.rb
+++ b/lib/attachy/models/attachy/viewer.rb
@@ -89,7 +89,7 @@ module Attachy
     end
 
     def hidden_field
-      @view.hidden_field @object.class.name.downcase, @method, value: value, id: nil
+      @view.hidden_field @object.class.name.underscore, @method, value: value, id: nil
     end
 
     def image(file = criteria, t: transform, html: htm)

--- a/spec/factories/admin_user.rb
+++ b/spec/factories/admin_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin_user do
+    sequence(:name) { |i| "Admin Name #{i}" }
+  end
+end

--- a/spec/models/attachy/viewer/hidden_field_spec.rb
+++ b/spec/models/attachy/viewer/hidden_field_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe Attachy::Viewer, '.hidden_field' do
 
     expect(el).to have_tag :input, with: { name: 'user[avatar]', type: 'hidden', value: 'value' }
   end
+
+  context 'when entity has a composed name' do
+    let!(:object) { create :admin_user }
+
+    it 'return the hidden field with an underscored name' do
+      el = subject.hidden_field
+
+      expect(el).to have_tag :input, with: { name: 'admin_user[avatar]', type: 'hidden', value: 'value' }
+    end
+  end
 end

--- a/spec/support/db/migrate/create_admin_user_table.rb
+++ b/spec/support/db/migrate/create_admin_user_table.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CreateAdminUsersTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :admin_users do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/spec/support/migrate.rb
+++ b/spec/support/migrate.rb
@@ -4,3 +4,4 @@ require File.expand_path('../../lib/generators/attachy/templates/db/migrate/crea
 
 CreateAttachyFilesTable.new.change
 CreateUsersTable.new.change
+CreateAdminUsersTable.new.change

--- a/spec/support/models/admin_user.rb
+++ b/spec/support/models/admin_user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AdminUser < ::ActiveRecord::Base
+  has_attachment :avatar, accept: %i[jpg png]
+end


### PR DESCRIPTION
# The problem

When creating the form field with the Attachy helper, things worked fine for classes with single word names, like `User`, with the `#downcase` method. But when the class had a composed name like `AdminUser` the result would be `adminuser` since `#downcase` only replaces uppercase chars with the downcased version.

## Before example:

```ruby
## View code
## ...
<%= f.attachy :avatar %>
<%= f.text_field :name %>

## Controller params inspect
params
# Output: <ActionController::Parameters {
#   "adminuser" => {
#     "avatar" => [...]
#   },
#   "admin_user"=> {
#     "name" => "Foo Bar"
#    }
# } permitted: false>
```

# The solution

Rails uses the `#underscore` method to generate the downcased underscore separed class names to generate form. So when composed words classes use the attachy helper the field would come in a different form data.

## After example

```ruby
## View code
## ...
<%= f.attachy :avatar %>
<%= f.text_field :name %>

## Controller params inspect
params
# Output: <ActionController::Parameters {
#   "admin_user"=> {
#     "name" => "Foo Bar"
#     "avatar" => [...]
#    }
# } permitted: false>
```

